### PR TITLE
Updated Numa_Report_v1.ps1

### DIFF
--- a/Numa_Report_v1.ps1
+++ b/Numa_Report_v1.ps1
@@ -39,12 +39,12 @@ ForEach ($c in $Clusters){
             }
 
                 #Find the smallest NUMA Node (CPU & Mem) to use for comparison
-                $x =  $HostSummary.NUMANodeSize | measure -Minimum
-                $y =  $HostSummary.CPUCoresSocket | measure -Minimum
+                $x =  $NUMAStats.NUMANodeSize | measure -Minimum
+                $y =  $NUMAStats.CPUCoresSocket | measure -Minimum
 
                 #Get list of all VMs in cluster that are oversized
                 $VMDeatils = @()
-                $VMDeatils = Get-VM -Location $c | where {$_.NumCpu -gt $v.Minimum -or $_.MemoryGB -gt $y.Minimum}
+                $VMDeatils = Get-VM -Location $c | where {$_.NumCpu -gt $y.Minimum -or $_.MemoryGB -gt $x.Minimum}
 
                 For($i = 1; $i -le $VMDeatils.count; $i++) {
                     Write-Progress -Activity "Processing VMs" ` -percentComplete ($i / $VMDeatils.count*100)


### PR DESCRIPTION
The way it is calculated the minimum for $HostSummary, will always get the value of the latest host that is iterated.
Changed from $HostSummary to $NUMAStats variable.
Also in line 47, the comparison against property "minimum" of variables was mistyped